### PR TITLE
Add priority parameter

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -79,6 +79,10 @@ class Event
      */
     protected $_callable      = [];
 
+    /**
+     * @var array
+     */
+    protected $_priorities = [];
 
 
     /**
@@ -186,10 +190,23 @@ class Event
      * @param   mixed   $callable    Callable.
      * @return  \Hoa\Event\Event
      */
-    public function attach($callable)
+    public function attach($callable, $priority = 0)
     {
-        $callable                              = xcallable($callable);
-        $this->_callable[$callable->getHash()] = $callable;
+        $callable                 = xcallable($callable);
+        $hash                     = $callable->getHash();
+        $this->_callable[$hash]   = $callable;
+        $this->_priorities[$hash] = (int) $priority;
+
+        uksort($this->_callable, function ($a, $b) {
+            $a = $this->_priorities[$a];
+            $b = $this->_priorities[$b];
+
+            /*if (70000 <= PHP_VERSION_ID) {
+                return $this->_priorities[$ka] <=> $this->_priorities[$kb];
+            }*/
+
+            return  ($a < $b) ? 1 : (($a > $b) ? -1 : 0);
+        });
 
         return $this;
     }

--- a/Test/Unit/Event.php
+++ b/Test/Unit/Event.php
@@ -186,6 +186,47 @@ class Event extends Test\Unit\Suite
                     ->isIdenticalTo($event)
                 ->boolean($event->isListened())
                     ->isTrue();
+
+        $this
+            ->given(
+                $eventId = 'hoa://Event/Test',
+                $source  = new \Mock\Hoa\Event\Source(),
+                $bucket  = new LUT\Bucket(),
+                $called  = '',
+
+                SUT::register($eventId, $source),
+                SUT::getEvent($eventId)->attach(
+                    function (LUT\Bucket $receivedBucket) use (&$called) {
+                        $called .= '1';
+                    }, 100
+                ),
+                SUT::getEvent($eventId)->attach(
+                    function (LUT\Bucket $receivedBucket) use (&$called) {
+                        $called .= '2';
+                    }, 10
+                ),
+                SUT::getEvent($eventId)->attach(
+                    function (LUT\Bucket $receivedBucket) use (&$called) {
+                        $called .= '3';
+                    }
+                ),
+                SUT::getEvent($eventId)->attach(
+                    function (LUT\Bucket $receivedBucket) use (&$called) {
+                        $called .= '3';
+                    }, 0
+                ),
+                SUT::getEvent($eventId)->attach(
+                    function (LUT\Bucket $receivedBucket) use (&$called) {
+                        $called .= '4';
+                    }, -1
+                )
+            )
+            ->when($result = SUT::notify($eventId, $source, $bucket))
+            ->then
+                ->variable($result)
+                    ->isNull()
+                ->string($called)
+                    ->isIdenticalTo('12334');
     }
 
     public function case_detach()


### PR DESCRIPTION
Hello,

I wrote this PR first before any issue because i had to write this patch for move forward on customer project.
I don't know if the state of art is good enough, but seems good to expose as a PR.

My case : I use `Hoa\Exception` and the power of event for handle correctly the translation of exception into a dedicated Library. But then i use this library into an App, and this app need be able to plug his own callable before library for catch specific exception and throw another dedicated to the library.

My solution was to add an integer argument to `attach` method for define priority level, higher is most important and called first.

https://continuousphp.com/git-hub/Pierozi/Event/build/6019f777-ed30-4923-882e-42a213021ff0/output
